### PR TITLE
Fix nvim-lspconfig example

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ client](https://neovim.io/doc/user/lsp.html) by adding it to `nvim-lspconfig`'s 
 servers:
 
 ```lua
-local lsp_configs = require('lspconfig/configs')
+local lsp_configs = require('lspconfig.configs')
 
 lsp_configs.prosemd = {
   default_config = {


### PR DESCRIPTION
The example was not working anymore. It said that the configuration was not present

```
Cannot access configuration for prosemd. Ensure this server is listed in `server_configurations.md` or added as a custom server.
```

Found the solution here 😉 
https://github.com/neovim/nvim-lspconfig/issues/1494#issuecomment-984337939